### PR TITLE
Added snip feature for desktop and remarkable tablet

### DIFF
--- a/zet
+++ b/zet
@@ -176,6 +176,29 @@ x_link() {
     fi
 }
 
+x_snip() {
+    local s3_images_region="us-west-1"
+    local s3_images_bucket="zettelimages"
+    # set temporary image location
+    image_loc="/tmp/$(date | sed 's/ /_/g').png"
+    if [[ "$1" == "pc" ]]; then
+        # screenshot desktop area and save image
+        gnome-screenshot -ap -f $image_loc # prompts user to select an area
+    elif [[ "$1" == "rm" ]]; then
+        # screenshot reMarkable tablet and save image
+        reSnap -s $REMARKABLE_IP -n -o $image_loc > /dev/null 2> /dev/null
+    elif [[ "$1" == "ipad" ]]; then
+        echo "Not yet implemented..."
+    else
+        echo "invalid usage: -h or --help for help"
+        exit 0
+    fi
+    # upload image to s3
+    aws s3api put-object --bucket $s3_images_bucket --key $(basename $image_loc) --body $image_loc --content-type="image/png" > /dev/null
+    # echo link to the s3 object
+    echo "![image](https://s3.$s3_images_region.amazonaws.com/$s3_images_bucket/$(basename $image_loc))"
+}
+
 ## post a zettelkasten link to twitter
 x_post() {
     local rc

--- a/zet
+++ b/zet
@@ -187,6 +187,9 @@ x_snip() {
     elif [[ "$1" == "rm" ]]; then
         # screenshot reMarkable tablet and save image
         reSnap -s $REMARKABLE_IP -n -o $image_loc > /dev/null 2> /dev/null
+     elif [[ "$1" == "select" ]]; then
+         # pick an image or gif from your computer
+         cp $(zenity --file-selection --file-filter='Image files | *.png *.jpg *.gif') $image_loc
     elif [[ "$1" == "ipad" ]]; then
         echo "Not yet implemented..."
     else


### PR DESCRIPTION
The intention of this feature is to create a way for integrating images into zettels. You must modify the code depending on your s3 bucket name and region.

Pre-requisites:
1. An S3 bucket with public access
2. For desktop screenshots on Ubuntu, `sudo apt install gnome-screenshot`. Otherwise, modify code accordingly for another screenshot command.
3. For remarkable screenshots, you need to configure `reSnap` [github.com/cloudsftp/reSnap](https://github.com/cloudsftp/reSnap). Also set your `$REMARKABLE_IP` environment variable.

[demo_video.zip](https://github.com/michaelarn0ld/zet/files/11595146/demo_video.zip)
